### PR TITLE
Support Ambient Weather weather service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,7 @@
 * Added option to set serial number
 * Changed history timer to make use of advantages in newer fakegato version
 * Fixed precipitation calculation in dark sky api
+
+## Future
+
+* Added support for Ambient Weather API

--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ With the eve app you can view the history for
 
 This plugin supports multiple weather services. Each has it's own advantages. The following table shows a comparison to help you choosing one.
 
-|                            |            Dark Sky (recommended)            |                   OpenWeatherMap                                 |                            Yahoo (currently offline)             |                   Weather Underground (legacy)                   |
-|----------------------------|:--------------------------------------------:|:----------------------------------------------------------------:|:----------------------------------------------------------------:|:----------------------------------------------------------------:|
-| Current observation values |                      15                      |                                7                                 |                                10                                |                                13                                |
-| Forecast values            |                      16                      |                                9                                |                                4                                  |                                10                                |
-| Forecast days              |                       7                      |                                 5                                |                                 10                               |                                 4                                |
-| Location                   |                geo-coordinates               |                city name, city id, geo-coordinates               |                            city name                             |                         city name or zip                         |
-| Personal weather stations  |                      :x:                     |                        :heavy_check_mark:                        |                                :x:                               |                        :heavy_check_mark:                        |
-| Free                       | :heavy_check_mark:                           |                        :heavy_check_mark:                        |                        :heavy_check_mark:                        | :x: (only legacy accounts)                                       |
-| Register                   | [here](https://darksky.net/dev/register)     | [here](https://openweathermap.org/appid)                         |                    not needed                                    | [here](https://www.wunderground.com/weather/api/) |
+|                            |            Dark Sky (recommended)          |             OpenWeatherMap                    |      Yahoo (currently offline)  |      Weather Underground (legacy)                 |  Ambient Weather                    |
+|----------------------------|:------------------------------------------:|:---------------------------------------------:|:-------------------------------:|:-------------------------------------------------:|:-----------------------------------:|
+| Current observation values |                      15                    |                          7                    |                10               |                   13                              |        11                           |
+| Forecast values            |                      16                    |                          9                    |                 4               |                   10                              |         0                           |
+| Forecast days              |                       7                    |                          5                    |                10               |                    4                              |         0                           |
+| Location                   |                geo-coordinates             |          city name, city id, geo-coordinates  |             city name           |            city name or zip                       |        PWS                          |
+| Personal weather stations  |                      :x:                   |                  :heavy_check_mark:           |               :x:               |           :heavy_check_mark:                      | :heavy_check_mark:                  |
+| Free                       | :heavy_check_mark:                         |                  :heavy_check_mark:           |     :heavy_check_mark:          | :x: (only legacy accounts)                        | :heavy_check_mark:                  |
+| Register                   | [here](https://darksky.net/dev/register)   | [here](https://openweathermap.org/appid)      |     not needed                  | [here](https://www.wunderground.com/weather/api/) | [here](https://ambientweather.net/) |
 
 *You can add more services by forking the project and submitting a pull request.*
 
@@ -199,6 +199,23 @@ The **location** parameter can be a city name or a zip. You can also use a stati
 ]
 ```
 
+### Ambient Weather
+
+The [Ambient Weather dashboard](https://dashboard.ambientweather.net/) records the information sent by an [Ambient Weather](https://www.ambientweather.com/) weather station. Set the **key** parameter to your device's API key, available from your [account page](https://dashboard.ambientweather.net/account). Set the **timezone** parameter to your time zone, for example `America/Los_Angeles` or `Europe/Paris`. See the [list of time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). The Ambient Weather service does not support forecasts.
+
+
+```json
+"platforms": [
+	{
+		"platform": "WeatherPlus",
+		"name": "WeatherPlus",
+		"service": "ambientweather",
+		"key": "XXXXXXXXXXXXXXX",
+		"timezone": "America/Los_Angeles",
+	}
+]
+```
+
 ## Example use cases
 
 - Switch on a blue light in the morning when the chance for rain is above 20% today (or white when the forecast condition is snow / yellow when it's sunny).
@@ -227,3 +244,4 @@ This plugin is a fork of [homebridge-weather-station](https://github.com/kcharwo
 - [Powered by Weather Underground](https://www.wunderground.com/)
 - [Powered by OpenWeatherMap](https://openweathermap.org/)
 - [Powered by Yahoo](https://yahoo.com/)
+- [Powered by Ambient Weather](https://www.ambientweather.net/)

--- a/api/ambientweather.js
+++ b/api/ambientweather.js
@@ -1,0 +1,156 @@
+/*jshint esversion: 6,node: true,-W041: false */
+"use strict";
+
+/*
+
+Ambient Weather API docs:
+  https://ambientweather.docs.apiary.io/
+
+Parameters returned by the Ambient Weather service:
+  https://github.com/ambient-weather/api-docs/wiki/Device-Data-Specs
+
+The Get Devices call is
+  https://api.ambientweather.net/v1/devices?applicationKey=APP_KEY&apiKey=API_KEY
+and the response is
+[
+  {
+    "macAddress": "xx:xx:xx:xx:xx:xx",
+    "lastData": {
+      "dateutc": 1549519740000,
+      "winddir": 68,
+      "windspeedmph": 0,
+      "windgustmph": 0,
+      "maxdailygust": 17.45,
+      "tempf": 39.4,
+      "battout": "1",
+      "humidity": 68,
+      "hourlyrainin": 0,
+      "eventrainin": 0,
+      "dailyrainin": 0,
+      "weeklyrainin": 2.17,
+      "monthlyrainin": 5.31,
+      "yearlyrainin": 12.46,
+      "totalrainin": 12.46,
+      "tempinf": 69.1,
+      "battin": "1",
+      "humidityin": 46,
+      "baromrelin": 30.2,
+      "baromabsin": 29.72,
+      "uv": 0,
+      "solarradiation": 0,
+      "temp1f": 67.28,
+      "humidity1": 47,
+      "batt1": "1",
+      "feelsLike": 39.4,
+      "dewPoint": 29.73,
+      "lastRain": "2019-02-05T20:12:00.000Z",
+      "date": "2019-02-07T06:09:00.000Z"
+    },
+    "info": {
+      "name": "Name",
+      "location": "Location"
+    }
+  }
+]
+
+*/
+
+const request = require('request'),
+    converter = require('../util/converter'),
+    moment = require('moment-timezone'),
+
+    attribution = 'Powered by Ambient Weather',
+    reportCharacteristics = [
+        'AirPressure',
+        'DewPoint',
+        'Humidity',
+        'ObservationTime',
+        'Rain1h',
+        'RainDay',
+        'SolarRadiation',
+        'Temperature',
+        'UVIndex',
+        'WindDirection',
+        'WindSpeed',
+        'WindSpeedMax'
+    ],
+    forecastCharacteristics = [],
+    forecastDays = 0;
+
+var appKey = '4967bf0124604a1c893164ee0758b4e0dcb568924f924b4498df4c3ce0db6f65';
+var debug, log;
+
+var init = function (apiKey, timezone, l, d) {
+    this.apiKey = apiKey;
+    this.timezone = timezone;
+
+    log = l;
+    debug = d;
+};
+
+var update = function (callback) {
+    debug("Updating weather with AmbientWeather");
+
+    const queryUri =
+          'https://api.ambientweather.net/v1/devices?applicationKey=' +
+          encodeURIComponent(appKey) +
+          '&apiKey=' +
+          encodeURIComponent(this.apiKey);
+
+    const tz = this.timezone;
+    request(queryUri, function (err, response, body) {
+        if (! err) {
+            const jsonObj = JSON.parse(body);
+            if (jsonObj.error) {
+                err = jsonObj.error;
+            } else {
+                parseReport(jsonObj[0].lastData, tz, callback);
+            }
+        }
+        if (err) {
+            log.error("Error retrieving weather report");
+            log.error("Error Message: " + err);
+            callback(err);
+        }
+    });
+};
+
+var parseReport = function (data, timezone, callback) {
+    const report = {};
+
+    // HomeKit expects SI units.
+
+    report.AirPressure = inchHgToHpa(data.baromrelin);
+    report.DewPoint = fahrenheitToCelsius(data.dewPoint);
+    report.Humidity = data.humidity;
+    report.ObservationTime = moment.unix(parseInt(data.dateutc / 1000))
+        .tz(timezone)
+        .format('HH:mm:ss');
+    report.Rain1h = inchToMm(data.hourlyrainin);
+    report.RainDay = inchToMm(data.dailyrainin);
+    report.SolarRadiation = data.solarradiationf;
+    report.Temperature = fahrenheitToCelsius(data.tempf);
+    report.UVIndex = data.uv;
+    report.WindDirection = converter.getWindDirection(data.winddir);
+    report.WindSpeed = mphToMps(data.windspeedmph);
+    report.WindSpeedMax = mphToMps(data.windgustmph);
+
+    const weather = {};
+    weather.report = report;
+    callback(null, weather);
+};
+
+var inchHgToHpa = function (inch_hg) { return inch_hg * 33.863886666667; };
+var fahrenheitToCelsius = function (f) { return (f - 32) * 5 / 9; };
+var inchToMm = function(inch) { return inch * 25.4; };
+var mphToMps = function(mph) { return mph * 0.4470389; };
+
+
+module.exports = {
+    init,
+    update,
+    reportCharacteristics,
+    forecastCharacteristics,
+    forecastDays,
+    attribution
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const darksky = require('./api/darksky'),
 	weatherunderground = require('./api/weatherunderground'),
 	openweathermap = require('./api/openweathermap'),
 	yahoo = require('./api/yahoo'),
+        ambientweather = require('./api/ambientweather'),
 	debug = require('debug')('homebridge-weather-plus'),
 	version = require('./package.json').version;
 
@@ -38,6 +39,7 @@ function WeatherStationPlatform(log, config, api) {
 	this.location = config.location;
 	this.locationGeo = config.locationGeo;
 	this.locationCity = config.locationCity;
+	this.timezone = config.timezone;
 	this.forecastDays = ('forecast' in config ? config.forecast : []);
 	this.language = ('language' in config ? config.language : 'en');
 	this.currentObservationsMode = ('currentObservations' in config ? config.currentObservations : 'normal');
@@ -76,6 +78,11 @@ function WeatherStationPlatform(log, config, api) {
 		debug("Using service Yahoo");
         yahoo.init(this.location, log, debug);
 		this.api = yahoo;
+	}
+	else if (service == 'ambientweather') {
+		debug("Using service AmbientWeather");
+		ambientweather.init(this.key, this.timezone, log, debug);
+		this.api = ambientweather;
 	}
 
 	// Update interval


### PR DESCRIPTION
The [Ambient Weather service](https://dashboard.ambientweather.net/) records the weather data sent by an Ambient Weather weather station.  The API documentation is at https://ambientweather.docs.apiary.io/.

The documentation says that API requests are limited to 3 requests per second per application key, and that the API will return a 429 response if this rate is exceeded.  If this becomes an issue, new application keys can be created with a link on the bottom of the [Ambient Weather account page](https://dashboard.ambientweather.net/account).