### PR TITLE
adding HOOBS Certification and HOOBS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm](https://img.shields.io/npm/dt/homebridge-weather-plus.svg?style=flat-square)](https://www.npmjs.com/package/homebridge-weather-plus)
 [![GitHub last commit](https://img.shields.io/github/last-commit/naofireblade/homebridge-weather-plus.svg?style=flat-square)](https://github.com/naofireblade/homebridge-weather-plus)
 [![Weather](https://img.shields.io/badge/weather-sunny-edd100.svg?style=flat-square)](https://github.com/naofireblade/homebridge-weather-plus)
+[![certified-hoobs-plugin](https://badgen.net/badge/HOOBS/Certified/yellow)](https://plugins.hoobs.org) [![hoobs-support](https://badgen.net/badge/HOOBS/Support/yellow)](https://support.hoobs.org)
 
 This is a weather plugin for [homebridge](https://github.com/nfarina/homebridge) that features current observations, daily forecasts and history graphs for multiple locations and services. You can download it via [npm](https://www.npmjs.com/package/homebridge-weather-plus).  
 


### PR DESCRIPTION
Hello @naofireblade 

We like to inform you that we have certified your Plugin directly for HOOBS as we no longer fork the plugin to certify it.

Your Plugin is set to automatically certify the Latest version you push to npm.

**Heres the Plugin site of your Plugin:**
https://plugins.hoobs.org/plugin/homebridge-weather-plus

_HOOBS Tab - shows the HOOBS customised Readme
Homebridge Tab - shows your Readme on npm_

Users can also write reviews there and we plan to extend it with an Plugin based forum.

All support will be done by HOOBS, and you can direct any HOOBS Users to our Support site:
http://support.hoobs.org

We will check if its an Issue related to HOOBS or an issue with the Plugin itself. If the second is the case we will contact you via issues on your GitHub repo.

We added two badges to your readme:

[![certified-hoobs-plugin](https://badgen.net/badge/HOOBS/Certified/yellow)](https://plugins.hoobs.org) [![hoobs-support](https://badgen.net/badge/HOOBS/Support/yellow)](https://support.hoobs.org)

Regards

Bobby @hoobs-org
