### PR TITLE
Update characteristics.js to increase UV index to 11

### DIFF
--- a/util/characteristics.js
+++ b/util/characteristics.js
@@ -387,7 +387,7 @@ module.exports = function (Characteristic, units)
 		Characteristic.call(this, 'UV Index', CustomUUID.UVIndex);
 		this.setProps({
 			format: Characteristic.Formats.UINT8,
-			maxValue: 10,
+			maxValue: 11,
 			minValue: 0,
 			minStep: 1,
 			perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]

--- a/util/characteristics.js
+++ b/util/characteristics.js
@@ -387,7 +387,7 @@ module.exports = function (Characteristic, units)
 		Characteristic.call(this, 'UV Index', CustomUUID.UVIndex);
 		this.setProps({
 			format: Characteristic.Formats.UINT8,
-			maxValue: 11,
+			maxValue: 12,
 			minValue: 0,
 			minStep: 1,
 			perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]


### PR DESCRIPTION
Correcting error where UV index was capped at 10.

[14/02/2022, 17:49:15] [homebridge-weather-plus] This plugin generated a warning from the characteristic 'UV Index': characteristic was supplied illegal value: number 11 exceeded maximum of 10. See https://git.io/JtMGR for more info.