### PR TITLE
Update openweathermap.js

### DIFF
--- a/apis/openweathermap.js
+++ b/apis/openweathermap.js
@@ -236,7 +236,7 @@ class OpenWeatherMapAPI
 	{
 		debug("Getting weather data for location %s", this.locationGeo);
 
-		const queryUri = "https://api.openweathermap.org/data/2.5/onecall?units=metric&lang=" + this.language + "&lat=" + this.locationGeo[0] + "&lon=" + this.locationGeo[1] + "&appid=" + this.apiKey;
+		const queryUri = "https://api.openweathermap.org/data/3.0/onecall?units=metric&lang=" + this.language + "&lat=" + this.locationGeo[0] + "&lon=" + this.locationGeo[1] + "&appid=" + this.apiKey;
 		request(encodeURI(queryUri),  (requestError, response, body) =>
 		{
 			if (!requestError)


### PR DESCRIPTION
Fixes the onecall API path to the current path at openweather.com.

Until a new version is available, you can manually correct this in your installation file to make it work again. But, as mentioned above, make as well sure you upgrade to the ONECALL product which comes with 1000 calls/day for free and can be capped at 1000 in the product settings to prevent unwanted payments.