### PR TITLE
Add Tempest WeatherFlow as a weather source

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ Used to indicate Weewx version.  The homekit plugin requires an location field t
 ```
 
 
+### Tempest Weatherflow
+
+The [Tempest Weatherflow]() is a local weather reporting device that publishes the current weather on the local network via [UDP packets](). Data is broadcast once per minute, so the Interval setting is ignored. As the physical station can only provide the current weather, future forecasts are not available with this weather source. This uses data published on your local network, and therefore runs fine without an internet connection. 
+
+```json
+"platforms": [
+    {
+        "platform": "WeatherPlus",
+        "service": "smartweather"
+    }
+]
+```
 
 ## Advanced Configuration
 
@@ -330,6 +342,7 @@ Many thanks to the awesome contributors who support the project with pull reques
 - [Zerosignal84](https://github.com/Zerosignal84) for fixing the uv index range
 - [Vincent Niehues](https://github.com/vniehues) for adding rain chance characteristic to the OpenWeatherMap api
 - [Hendrik-Cv](https://github.com/Hendrik-Cv) for updating the OpenWeatherMap api to v3.0
+- [David Carson](https://github.com/dacarson) for integration with Tempest WeatherFlow
 
 Also thanks to numerous people helping with the docs.
 

--- a/accessories/currentConditions.js
+++ b/accessories/currentConditions.js
@@ -47,6 +47,18 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			this.log.debug("Separating humidity into an extra service");
 			this.HumidityService = new Service.HumiditySensor("Humidity")
 		}
+		
+		// Separate light level into a single service if configurated
+		if (this.config.extraLightLevel)
+		{
+			this.log.debug("Separating light level into an extra service");
+			this.LightLevelService = new Service.LightSensor("Light Level");
+			this.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+				.setProps({
+					minValue: 0,
+					maxValue: 200000
+				});
+		}
 	}
 
 
@@ -88,6 +100,33 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			else if (name === "Humidity")
 			{
 				this.CurrentConditionsService.addCharacteristic(Characteristic.CurrentRelativeHumidity);
+			}
+			// Use separate service for light level if configured
+			else if (this.config.compatibility === "eve" && name === "LightLevel" && this.config.extraLightLevel)
+			{
+				//
+			}
+			// illuminance is a general apple home kit characteristic
+			else if (name === "LightLevel")
+			{
+				this.CurrentConditionsService.addCharacteristic(Characteristic.CurrentAmbientLightLevel);
+				// Override the defaults for light level as default is too low for daylight
+				this.CurrentConditionsService.getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+					.setProps({
+						minValue: 0,
+						maxValue: 200000,
+						minStep: 1
+					});
+			}
+			// Battery level is a general apple home kit characteristic
+			else if (name === "BatteryLevel")
+			{
+				this.CurrentConditionsService.addCharacteristic(Characteristic.BatteryLevel);
+			}
+						// Battery level is a general apple home kit characteristic
+			else if (name === "BatteryIsCharging")
+			{
+				this.CurrentConditionsService.addCharacteristic(Characteristic.ChargingState);
 			}
 			// Add everything else as a custom characteristic to the temperature service
 			else

--- a/apis/smartweather.js
+++ b/apis/smartweather.js
@@ -1,0 +1,391 @@
+"use strict";
+
+const converter = require('../util/converter'),
+	moment = require('moment-timezone'),
+	dgram = require("dgram"),
+	wformula = require('weather-formulas');
+
+// To make debug lines appear, set Env variable DEBUG to homebridge-weather-plus
+
+// TODO: Extract out calculated values into common function
+
+	
+class SmartWeatherAPI
+{
+	constructor (log)
+	{
+		this.attribution = 'Powered by Smart Weather';
+		this.reportCharacteristics = [
+			'AirPressure', // Station Pressure
+			'ConditionCategory', // Precipitation Type
+			'DewPoint', // Calculated from Humidity & Temperature
+			'TemperatureApparent', // Calculdated from Humidity, Temperature & Windspeed
+			'Humidity', // Relative Humidity
+			'ObservationStation', // Serial Number of Hub
+			'ObservationTime', // Time Epoch
+			'Rain1h', // Rain Accumulated
+			'RainDay', // Local Day Rain Accumulation
+			'SolarRadiation', // Solar Radiation
+			'Temperature', // Air Temperature
+			'TemperatureMin', // Minimum temperature
+			'TemperatureWetBulb', // Wet Bulb Temperature
+			'UVIndex', // UV
+			'WindDirection', // Wind Direction
+			'WindSpeed', // Wind Avg
+			'WindSpeedMax', // Wind Gust
+			'WindSpeedLull', // Wind Lull
+			'LightningStrikes', // Count of lightning Strikes over last hour?
+			'LightningAvgDistance', // Average distance to the lightning strikes
+			'LightLevel', // Illuminance
+			'BatteryLevel', // Device Battery level percent
+			'BatteryIsCharging' // Device Battery charging state
+		];
+	
+		this.log = log;
+		this.rainAccumulation = [];
+		// Fill the array with zeros so that when we sum them up, it doesn't get NaN
+		for (var i = 0; i < 60; i++) this.rainAccumulation[i] = 0.0;
+		this.rainAccumulationMinute = 0;
+		
+		this.currentReport = {};
+	
+		this.currentReport.AirPressure = 0;
+		this.currentReport.Condition = "Unknown";
+		this.currentReport.ConditionCategory = 0;
+		this.currentReport.Humidity = 1;
+		this.currentReport.ObservationStation = "Unknown";
+		this.currentReport.ObservationTime = moment().format('HH:mm:ss');
+		this.currentReport.Rain1h = 0.0;
+		this.currentReport.RainDay = 0.0;
+		this.currentReport.SolarRadiation = 0;
+		this.currentReport.Temperature = 0;
+		this.currentReport.TemperatureApparent = 0;
+		this.currentReport.TemperatureMin = 50;
+		this.currentReport.DewPoint = 0;
+		this.currentReport.UVIndex = 0;
+		this.currentReport.WindDirection = converter.getWindDirection(0);
+		this.currentReport.WindSpeed = 0;
+		this.currentReport.WindSpeedMax = 0;
+		
+		// Extras
+		this.currentReport.BatteryLevel = 100;
+		this.currentReport.BatteryIsCharging = false;
+		this.currentReport.WindSpeedLull = 0;
+		this.currentReport.LightningStrikes = 0;
+		this.currentReport.LightningAvgDistance = 0;
+		this.currentReport.LightLevel = 0;
+		this.currentReport.TemperatureWetBulb = 0;
+
+		// Non-exposed Weather report characteristics
+		this.currentReport.SkySensorBatteryLevel = 100;
+		this.currentReport.SkySerialNumber = "SK-";
+		this.currentReport.SkyFirmware = "1.0";
+		this.currentReport.AirSensorBatteryLevel = 100;
+		this.currentReport.AirSerialNumber = "AR-";
+		this.currentReport.AirFirmware = "1.0";
+		this.currentReport.LightLevelSensorFail = 0;
+		this.currentReport.HumiditySensorFail = 0;
+		this.currentReport.TemperatureSensorFail = 0;
+
+	
+		// Create UDP listener and start listening
+		this.server = dgram.createSocket({type: 'udp4', reuseAddr: true});
+		this.server.on('error', (err) => {
+			  this.log(`server error:\n${err.stack}`);
+			  this.server.close();
+			  });
+	
+		this.server.on('message', (msg, rinfo) => {
+			try {
+				var message = JSON.parse(msg);
+				this.log.debug(`Server got: ${message.type}`);
+				this.parseMessage(message);
+				}
+			catch(ex) {
+				this.log(`JSON Parse Exception: ${msg} ${ex}`);
+				}
+			});
+	
+		this.server.on('listening', () => {
+			  const address = this.server.address();
+			  this.log(`server listening ${address.address}:${address.port}`);
+			  });
+	
+		this.server.bind(50222);
+	}
+	
+	update(forecastDays, callback)
+	{
+		this.log.debug("Updating weather with smart weather");
+
+		let weather = {};
+		weather.forecasts = [];
+		let that = this;
+		weather.report = that.currentReport;
+		callback(null, weather);
+	}
+
+	// Calculate Wet Bulb Temperature
+	getWetBulbTemperature(dryBulbTemperature, relativeHumidity)
+	{
+		let T = dryBulbTemperature;
+		let rh = relativeHumidity;
+
+		let c1 = 0.152;
+		let c2 = 8.3136;
+		let c3 = 0.5;
+		let c4 = 1.6763;
+		let c5 = 0.00391838;
+		let c6 = 1.5;
+		let c7 = 0.0231;
+		let c8 = 4.686;
+
+		let Tw = T * Math.atan(c1 * Math.pow((rh + c2), c3)) +
+			Math.atan(T+rh) - Math.atan(rh-c4) + 
+			c5 * Math.pow(rh, c6) * Math.atan(c7 * rh) - c8;
+
+		return Tw;
+	}
+
+
+	// Map Smart Weather precipitation values to Eve Condition Categories
+	getConditionCategorySmartWeather(precipitationType)
+	{
+	// Eve: 0 = clear; 3 = snow/hail; 2 = rain; 1 = overcast
+
+		if (precipitationType == 1) {
+			// Rain
+			return 2;
+		} else if (precipitationType == 2) {
+			// Hail
+			return 3;
+		} else {
+			// 0 = Clear
+			return 0;
+		}
+	}
+
+	// Relying on the update happening every minute
+	getHourlyAccumulatedRain(mmOfRainInLastMinute)
+	{
+		let that = this;
+		
+		that.rainAccumulation[that.rainAccumulationMinute] = mmOfRainInLastMinute;
+	
+		// Look at using the converter function getRainAccumulated(array[values][field], field)
+		var accumulation = 0.0;
+		for (var i = 0; i < 60; i++) {
+			accumulation += parseFloat(that.rainAccumulation[i]);
+		}
+	
+		that.rainAccumulationMinute++;
+		if (that.rainAccumulationMinute > 59) {
+			that.rainAccumulationMinute = 0;
+		}
+		this.log.debug("getHourlyAccumulatedRain last minute: " + mmOfRainInLastMinute + " last hour: " + accumulation);
+		return accumulation;
+	}
+
+	// Assume that zero battery level is 2.6v
+	getBatteryPercent(batteryVoltage)
+	{
+		return (batteryVoltage * 100 - 260);
+	}
+	
+	// Tempest battery ranges from 2.30 (flat) to 2.65 (full)
+	getTempestBatteryPercent(batteryVoltage)
+	{
+		var percent = (batteryVoltage * 100.0 - 230.0)/0.3;
+		return (percent > 100) ? 100 : (percent < 0.0) ? 0 : percent;
+	}
+	
+
+	// API: https://weatherflow.github.io/SmartWeather/api/udp/v119/
+	parseMessage(message)
+	{
+		let that = this;
+		
+		if (message.type == 'device_status') {
+			that.currentReport.ObservationStation = message.serial_number;
+			that.currentReport.ObservationTime = moment.unix(message.timestamp).format('HH:mm:ss');
+			that.currentReport.TemperatureSensorFail = (message.sensor_status & 0x00000010) ? 1 : 0;
+			that.currentReport.HumiditySensorFail = (message.sensor_status & 0x00000020) ? 1 : 0;
+			that.currentReport.LightLevelSensorFail = (message.sensor_status & 0x00000100) ? 1 : 0;
+			// TODO: Check if a sensor has failed, and log it!
+			this.log.debug("Temperature Sensor Fail: %d, Humidity Sensor Fail: %d, Light Level Sensor Fail: %d", 
+				that.currentReport.TemperatureSensorFail, 
+				that.currentReport.HumiditySensorFail, 
+				that.currentReport.LightLevelSensorFail);
+			var previousLevel = that.currentReport.BatteryLevel;
+			that.currentReport.BatteryIsCharging = false;
+			if (message.serial_number.charAt(1) == 'T') {  // Tempest 
+				that.currentReport.BatteryLevel = this.getTempestBatteryPercent(message.voltage);
+			} else {
+				that.currentReport.BatteryLevel = this.getBatteryPercent(message.voltage);
+			}
+			if (that.currentReport.BatteryLevel > previousLevel) {
+				that.currentReport.BatteryIsCharging = true;
+			}
+		}
+		
+		if (message.type == 'evt_precip') {
+			// Only update if it isn't raining already
+			if (that.currentReport.ConditionCategory != 2) {
+				that.currentReport.ObservationStation = message.serial_number;
+				that.currentReport.ObservationTime = moment.unix(message.evt[0]).format('HH:mm:ss');
+				that.currentReport.ConditionCategory = 2; // It's raining
+			}
+		}
+		
+		if (message.type == 'rapid_wind') {
+			that.currentReport.ObservationStation = message.serial_number;
+			that.currentReport.ObservationTime = moment.unix(message.ob[0]).format('HH:mm:ss');
+			that.currentReport.WindSpeed = message.ob[1];
+			that.currentReport.WindDirection = converter.getWindDirection(message.ob[2]);
+		}
+		
+		if (message.type == 'obs_air') {
+			that.currentReport.AirSerialNumber = message.serial_number;
+			that.currentReport.ObservationStation = that.currentReport.AirSerialNumber;
+			that.currentReport.AirFirmware = message.firmware_revision;
+			that.currentReport.ObservationTime = moment.unix(message.obs[0][0]).format('HH:mm:ss');
+			that.currentReport.AirPressure = message.obs[0][1];
+			if (that.currentReport.TemperatureSensorFail == 1)
+				that.currentReport.Temperature = 0;
+			else
+				that.currentReport.Temperature = message.obs[0][2];
+			if (that.currentReport.HumiditySensorFail == 1) {
+				that.currentReport.Humidity = 0;
+				that.currentReport.DewPoint = 0;
+			}
+			else {
+				that.currentReport.Humidity = message.obs[0][3];
+				that.currentReport.DewPoint = wformula.kelvinToCelcius(wformula.dewPointMagnusFormula(
+					wformula.celciusToKelvin(that.currentReport.Temperature), 
+					that.currentReport.Humidity));
+			}
+			that.currentReport.TemperatureApparent = wformula.kelvinToCelcius(wformula.australianAapparentTemperature(
+					wformula.celciusToKelvin(that.currentReport.Temperature),
+					that.currentReport.Humidity,
+					that.currentReport.WindSpeed));
+			that.currentReport.TemperatureMin = (that.currentReport.Temperature < that.currentReport.TemperatureMin) ?
+					that.currentReport.Temperature : that.currentReport.TemperatureMin;
+			that.currentReport.TemperatureWetBulb = 
+					this.getWetBulbTemperature(that.currentReport.Temperature, that.currentReport.Humidity);
+			that.currentReport.LightningStrikes = message.obs[0][4];
+			that.currentReport.LightningAvgDistance = message.obs[0][5];
+			that.currentReport.AirSensorBatteryLevel = this.getBatteryPercent(message.obs[0][6]);
+		}
+
+		if (message.type == 'obs_sky') {
+			that.currentReport.SkySerialNumber = message.serial_number;
+			that.currentReport.ObservationStation = that.currentReport.SkySerialNumber;
+			that.currentReport.SkyFirmware = message.firmware_revision;
+			that.currentReport.ObservationTime = moment.unix(message.obs[0][0]).format('HH:mm:ss');
+			if (that.currentReport.LightLevelSensorFail == 1)
+				that.currentReportLightLevel = 0;
+			else
+				that.currentReport.LightLevel = message.obs[0][1];
+			that.currentReport.UVIndex = message.obs[0][2];
+			that.currentReport.Rain1h = this.getHourlyAccumulatedRain(message.obs[0][3]);
+		
+			// Use wind values reported by rapid_wind as they are instantanous,
+			// whereas obs_sky are averaged values over last minute
+			//that.currentReport.WindSpeed = message.obs[0][5];
+			//that.currentReport.WindDirection = converter.getWindDirection(message.obs[0][7]);
+			
+			// Wind values are min/max over last minute
+			that.currentReport.WindSpeedLull = message.obs[0][4];
+			that.currentReport.WindSpeedMax = message.obs[0][6];
+			
+			that.currentReport.SkySensorBatteryLevel = this.getBatteryPercent(message.obs[0][8]);
+			that.currentReport.SolarRadiation = message.obs[0][10];
+			// currentReport.RainDay = message.obs[0][11];
+			// Note that Local Day Rain Accumulation (Field 11) is always null as it is calculate at WeatherFlow
+			if (that.rainDayDate === moment.unix(message.obs[0][0]).format('DD')) {
+				that.currentReport.RainDay += parseFloat(message.obs[0][3]);
+			} else {
+				that.rainDayDate = moment.unix(message.obs[0][0]).format('DD');
+				that.currentReport.RainDay = parseFloat(message.obs[0][3]);
+				that.currentReport.TemperatureMin = that.currentReport.Temperature;
+			}
+			that.currentReport.ConditionCategory = this.getConditionCategorySmartWeather(message.obs[0][12]);
+		}
+
+       if (message.type == 'obs_st') {
+            that.currentReport.SkySerialNumber = message.serial_number;
+      	    that.currentReport.ObservationStation = that.currentReport.SkySerialNumber;
+            that.currentReport.SkyFirmware = message.firmware_revision;
+            that.currentReport.ObservationTime = moment.unix(message.obs[0][0]).format('HH:mm:ss');
+            
+            // Wind values are min/max over last minute
+            that.currentReport.WindSpeedLull = message.obs[0][1];
+            that.currentReport.WindSpeedMax = message.obs[0][3];
+            // Use wind values reported by rapid_wind as they are instantanous,
+            // whereas obs_sky are averaged values over last minute
+            //that.currentReport.WindSpeed = message.obs[0][2];
+            //that.currentReport.WindDirection = converter.getWindDirection(message.obs[0][4]);
+            
+            that.currentReport.AirPressure = message.obs[0][6];
+	    if (that.currentReport.TemperatureSensorFail == 1)
+	            that.currentReport.Temperature = 0;
+	    else
+	            that.currentReport.Temperature = message.obs[0][7];
+            if (that.currentReport.HumiditySensorFail == 1) {
+                that.currentReport.Humidity = 0;
+                that.currentReport.DewPoint = 0;
+            }
+            else {
+                that.currentReport.Humidity = message.obs[0][8];
+                that.currentReport.DewPoint = wformula.kelvinToCelcius(wformula.dewPointMagnusFormula(
+					wformula.celciusToKelvin(that.currentReport.Temperature), 
+					that.currentReport.Humidity));
+            }
+	    that.currentReport.TemperatureApparent = wformula.kelvinToCelcius(wformula.australianAapparentTemperature(
+					wformula.celciusToKelvin(that.currentReport.Temperature),
+					that.currentReport.Humidity,
+					message.obs[0][2]));
+	    that.currentReport.TemperatureWetBulb = 
+					this.getWetBulbTemperature(that.currentReport.Temperature, that.currentReport.Humidity);
+	    if (that.currentReport.LightLevelSensorFail == 1)
+                that.currentReport.LightLevel = 0;
+	    else
+                that.currentReport.LightLevel = message.obs[0][9];
+            that.currentReport.UVIndex = message.obs[0][10];
+            that.currentReport.SolarRadiation = message.obs[0][11];
+            that.currentReport.Rain1h = this.getHourlyAccumulatedRain(message.obs[0][12]);
+            if (that.rainDayDate === moment.unix(message.obs[0][0]).format('DD')) {
+		this.log.debug("Adding rain " + parseFloat(message.obs[0][12]) + " for day " + that.rainDayDate);
+                that.currentReport.RainDay += parseFloat(message.obs[0][12]);
+                that.currentReport.TemperatureMin = (that.currentReport.Temperature < that.currentReport.TemperatureMin) ?
+					that.currentReport.Temperature : that.currentReport.TemperatureMin;
+            } else {
+		this.log.debug("Creating new count for rain " + parseFloat(message.obs[0][12]) + " for day " + that.rainDayDate);
+                that.rainDayDate = moment.unix(message.obs[0][0]).format('DD');
+                that.currentReport.RainDay = parseFloat(message.obs[0][12]);
+                that.currentReport.TemperatureMin = that.currentReport.Temperature;
+            }
+            that.currentReport.ConditionCategory = this.getConditionCategorySmartWeather(message.obs[0][13]);
+            that.currentReport.LightningAvgDistance = message.obs[0][14];
+            that.currentReport.LightningStrikes = message.obs[0][15];
+            that.currentReport.SkySensorBatteryLevel = this.getTempestBatteryPercent(message.obs[0][16]);
+            var previousLevel = that.currentReport.BatteryLevel;
+			that.currentReport.BatteryIsCharging = false;
+			that.currentReport.BatteryLevel = that.currentReport.SkySensorBatteryLevel;
+			if (that.currentReport.BatteryLevel > previousLevel) {
+				that.currentReport.BatteryIsCharging = true;
+			}
+            
+        }
+	}
+	parseForecasts(forecastObjs, timezone)
+	{
+		/* NO FORECAST DATA FROM API */
+		return [];
+	}
+
+}
+
+module.exports = {
+	SmartWeatherAPI: SmartWeatherAPI
+};

--- a/config.schema.json
+++ b/config.schema.json
@@ -65,6 +65,10 @@
               {
                 "title": "Weewx",
                 "const": "weewx"
+              },
+              {
+                "title": "Tempest Weather Station",
+                "const": "smartweather"
               }
             ]
           },
@@ -334,7 +338,10 @@
             },
             {
               "key": "stations[].key",
-              "notitle": true
+              "notitle": true,
+              "condition": {
+                "functionBody": "return model.stations[0].service != 'smartweather'"
+              }
             },
             {
               "type": "help",

--- a/util/characteristics.js
+++ b/util/characteristics.js
@@ -30,7 +30,13 @@ const inherits = require('util').inherits,
 		Visibility: 'd24ecc1e-6fad-4fb5-8137-5af88bd5e857',
 		WindDirection: '46f1284c-1912-421b-82f5-eb75008b167e',
 		WindSpeed: '49C8AE5A-A3A5-41AB-BF1F-12D5654F9F41',
-		WindSpeedMax: '6b8861e5-d6f3-425c-83b6-069945ffd1f1'
+		WindSpeedMax: '6b8861e5-d6f3-425c-83b6-069945ffd1f1',
+		
+		// Custom UUIDs
+		LightningStrikes: '848c304a-97fe-41df-b284-ec2e2a6f5104',
+		LightningAvgDistance: '903043ee-2e82-4272-901e-871d775a4747',
+		WindSpeedLull: 'c3b4c4f8-79b7-4b1a-be3c-765ac065c379',
+		TemperatureWetBulb: 'dc5c6ca2-ec2c-4d32-8e7a-db4288c2b8d5'
 	};
 
 let CustomCharacteristic = {};
@@ -433,6 +439,43 @@ module.exports = function (Characteristic, units)
 	};
 	inherits(CustomCharacteristic.WindSpeedMax, Characteristic);
 	CustomCharacteristic.WindSpeedMax._unitvalue = windspeedValue;
+
+    CustomCharacteristic.WindSpeedLull = function () {
+        Characteristic.call(this, 'Wind Speed Lull', CustomUUID.WindSpeedLull);
+        this.setProps(windspeedProps(100));
+        this.value = this.getDefaultValue();
+    };
+    inherits(CustomCharacteristic.WindSpeedLull, Characteristic);
+    CustomCharacteristic.WindSpeedLull._unitvalue = windspeedValue;
+    
+	CustomCharacteristic.LightningStrikes = function () {
+        Characteristic.call(this, 'Lightning Strikes', CustomUUID.LightningStrikes);
+        this.setProps({
+            format: Characteristic.Formats.UINT8,
+            maxValue: 1000,
+            minValue: 0,
+            minStep: 1,
+            perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+        });
+        this.value = this.getDefaultValue();
+    };
+    inherits(CustomCharacteristic.LightningStrikes, Characteristic);
+    
+    CustomCharacteristic.LightningAvgDistance = function () {
+        Characteristic.call(this, 'Lightning Avg Distance', CustomUUID.LightningAvgDistance);
+        this.setProps(visibilityProps(100));
+        this.value = this.getDefaultValue();
+    };
+    inherits(CustomCharacteristic.LightningAvgDistance, Characteristic);
+    CustomCharacteristic.LightningAvgDistance._unitvalue = visibilityValue;
+
+    CustomCharacteristic.TemperatureWetBulb = function ()
+	{
+		Characteristic.call(this, 'Wet-bulb temperature', CustomUUID.TemperatureWetBulb);
+		this.setProps(temperatureProps(-50, 100));
+		this.value = this.getDefaultValue();
+	};
+	inherits(CustomCharacteristic.TemperatureWetBulb, Characteristic);
 
 	return CustomCharacteristic;
 };

--- a/util/compatibility.js
+++ b/util/compatibility.js
@@ -1,7 +1,7 @@
 /*jshint esversion: 6,node: true,-W041: false */
 "use strict";
 
-const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "RainBool", "SnowBool", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
+const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "LightLevel", "RainBool", "SnowBool", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
 
 const createService = function (that, name, Service, Characteristic, CustomCharacteristic)
 {
@@ -27,6 +27,15 @@ const createService = function (that, name, Service, Characteristic, CustomChara
 	{
 		that.HumidityService = new Service.HumiditySensor("Humidity");
 	}
+	if (name === "LightLevel")
+	{
+		that.LightLevelService = new Service.LightSensor("Light Level");
+		that.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel)
+                                        .setProps({
+                                                minValue: 0.0,
+                                                maxValue: 200000.0
+                                        });
+	}
 	if (name === "RainBool")
 	{
 		that.RainBoolService = new Service.OccupancySensor("Rain", "Rain");
@@ -44,6 +53,11 @@ const createService = function (that, name, Service, Characteristic, CustomChara
 	{
 		that.TemperatureApparentService = new Service.TemperatureSensor("Apparent Temperature", "TemperatureApparent");
 		that.TemperatureApparentService.getCharacteristic(Characteristic.CurrentTemperature).props.minValue = -50;
+	}
+	if (name === "TemperatureWetBulb")
+	{
+		that.TemperatureWetBulbService = new Service.TemperatureSensor("Wet-Bulb Temperature", "TemperatureWetBulb");
+		that.TemperatureWetBulbService.getCharacteristic(Characteristic.CurrentTemperature).props.minValue = -50;
 	}
 	if (name === "UVIndex")
 	{


### PR DESCRIPTION
Changes per file.
api/smartweather.js:
1. WeatherFlow broadcasts UDP packets on the local network. This adds a UDP listener for events, parses them and stores them in the relative parameters.
2. This file requires UDP support so it requires (dgram)
3. Also make use of standard weather formulas for some calculations (weather-formulas)

Index.api:
1. There is no geo location for the weather station is it is assumed to be in the Home
2. UDP packets are broadcast on the local network and picked up by the plugin. WeatherFlow broadcasts new data every minute, so the update interval is fixed to 1 minute.
3. As a local wether station, there are a couple of new characteristics that it has: 1. Light level (Illuminance) is available. As light level is a standard HomeKit characteristic, I coded it in the same style as humidity. 2. Weatherflow devices are battery powered, some with solar to charge. I added a battery characteristic for this data source too, similar to light level. 4.

util/compatibility.js:
1. The default min/max for light level are too restricted for outdoor light levels (lux), increase the range to support outside light levels
2. Add another temperature object to support WetBulb temperature

util/characteristics.js
1. There are four additional characteristics that I believe are interesting to show. 1. Data reported by the WeatherFlow hardware. LightningStrikes (count of lightning strikes in the area), LightningAvgDistance (the average distance of the strikes) and WindLull (Idle wind speed). 2. TemperatureWetBulb. Calculated characteristic from humidity and temperature. Found it to be useful when viewing the current weather status.

accessories/currentConditions.js
1. Added support for the HomeKit characteristics LightLevel and Battery

config.schema.json
1. Add Tempest WeatherFlow as an option.

README.md
1. Add information about Tempest WeatherFlow option