### PR TITLE
Fix Tempest Weatherflow issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,3 +263,7 @@
 
 ## 3.3.0
 * Add support for WeatherFlow's Tempest weather station, that reports real time weather data over local network.
+
+## 3.3.1
+* Tempest: Fix JSON parse issue for rain events
+* Tempest: Fix serial number to allow it to be unique so History events don't get merged with other weather stations

--- a/apis/weatherflow.js
+++ b/apis/weatherflow.js
@@ -307,7 +307,7 @@ class TempestAPI
 		if (message.type == 'evt_precip') {
 			that.currentReport.ObservationStation = message.serial_number;
 			that.currentReport.ObservationTime = moment.unix(message.evt[0]).format('HH:mm:ss');
-			that.currentReport.ConditionCategory = getConditionCategory(1, this.conditionDetail); // It has started to rain
+			that.currentReport.ConditionCategory = this.getConditionCategory(1, this.conditionDetail); // It has started to rain
 			that.currentReport.RainBool = true;
 		}
 		

--- a/config.schema.json
+++ b/config.schema.json
@@ -350,12 +350,19 @@
                 "functionBody": "return model.stations[0].service === 'openweathermap'"
               }
             },
+			{
+              "type": "help",
+              "helpvalue": "<h6>City</h6><p class='help-block'>City only needed with Tempest when Eve app is used with multiple weather stations (same or different homes)</a>.</p>",
+              "condition": {
+                "functionBody": "return model.stations[0].service === 'tempest'"
+              }
+            },
             {
               "key": "stations[].locationCity",
               "notitle": true,
               "placeholder": "Berlin, DE",
               "condition": {
-                "functionBody": "return model.stations[0].service === 'openweathermap'"
+                "functionBody": "return model.stations[0].service === 'openweathermap' ||  model.stations[0].service === 'tempest'"
               }
             },
             {

--- a/index.js
+++ b/index.js
@@ -88,8 +88,6 @@ function WeatherPlusPlatform(_log, _config)
 				this.log.info("Adding station with weather service TempestAPI named '" + config.nameNow + "'");
 				this.stations.push(new tempest(config.conditionDetail, this.log, HomebridgeAPI.user.persistPath()));
 				this.interval = 1;  // Tempest broadcasts new data every minute
-				// Set a location city so that in HomeKit the Serial Number is reported as "tempest - local"
-				this.locationCity = "local";
 				break;
 			default:
 				this.log.error("Unsupported weather service: " + config.service);
@@ -149,6 +147,11 @@ WeatherPlusPlatform.prototype = {
 		station.locationId = stationConfig.locationId || station.locationId;
 		station.locationGeo = stationConfig.locationGeo;
 		station.locationCity = stationConfig.locationCity;
+		if (!station.locationCity && (station.service === "tempest"))
+		{
+			// If location city is not set for Tempest, set it so that in HomeKit the Serial Number is reported as "tempest - local"
+			this.locationCity = "local";
+		}
 		if (!station.locationId && !station.locationCity && !station.locationGeo && !(station.service === "tempest"))
 		{
 			this.log.error("No location configured for station: " + station.service + ". Please provide locationId, locationCity or locationGeo for each station.")


### PR DESCRIPTION
Fix the JSON parse issue when it is raining - evt_precip event tries to use a function that is not in scope.
Fix #269, use the locationCity correctly to make a unique weather station serial number, and avoiding history information from being merged.