### PR TITLE
Fix Tempest breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,3 +277,4 @@
 
 ## 3.3.3
 * Fix Tempest weather station breakage introduced in 3.3.2
+* Fix Rain accumulation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,3 +274,6 @@
 * Fixed undefined rain boolean sensor value
 * Fixed several Tempest weather station issues
 * Improved usage of converter
+
+## 3.3.3
+* Fix Tempest weather station breakage introduced in 3.3.2

--- a/apis/weatherflow.js
+++ b/apis/weatherflow.js
@@ -218,7 +218,7 @@ class TempestAPI
 			that.rainAccumulation[currentObservationMinute] += mmOfRainInLastMinute;
 		else {
 			// Erase the minutes between last recorded minute and current minute
-			for (var i = that.rainAccumulationMinute; (i % 60) != currentObservationMinute; i++)
+			for (var i = that.rainAccumulationMinute + 1; (i % 60) != currentObservationMinute; i++)
 				that.rainAccumulation[i % 60] = 0;
 			that.rainAccumulation[currentObservationMinute] = mmOfRainInLastMinute;
 		}
@@ -226,7 +226,7 @@ class TempestAPI
 	
 		var accumulation = converter.getRainAccumulated(that.rainAccumulation)
 	
-		this.log.debug("getHourlyAccumulatedRain last minute: " + mmOfRainInLastMinute + " last hour: " + accumulation);
+		this.log.debug("getHourlyAccumulatedRain last minute: " + mmOfRainInLastMinute + " rainAccumulation: " + this.rainAccumulation + " last hour: " + accumulation);
 		return accumulation;
 	}
 

--- a/apis/weatherflow.js
+++ b/apis/weatherflow.js
@@ -224,7 +224,7 @@ class TempestAPI
 		}
 		that.rainAccumulationMinute = currentObservationMinute;
 	
-		accumulation = converter.getRainAccumulated(that.rainAccumulation)
+		var accumulation = converter.getRainAccumulated(that.rainAccumulation)
 	
 		this.log.debug("getHourlyAccumulatedRain last minute: " + mmOfRainInLastMinute + " last hour: " + accumulation);
 		return accumulation;
@@ -438,3 +438,4 @@ class TempestAPI
 module.exports = {
 	TempestAPI: TempestAPI
 };
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-weather-plus",
   "displayName": "Weather Plus",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "A comprehensive weather plugin for homekit with current observations, forecasts and history.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fix #278, add missing variable declaration.

Lived on 3.3.2 with this change and only this change for two days. During which time it rained. I verified that this fix will correct the breakage introduced in 278, and I have not observed any other issues.