### PR TITLE
Update currentConditions.js

### DIFF
--- a/accessories/currentConditions.js
+++ b/accessories/currentConditions.js
@@ -141,7 +141,7 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			}
 		}
 	});
-	this.services.concat(compatibility.getServices(this));
+	this.services = this.services.concat(compatibility.getServices(this));
 
 	// Create information service
 	this.informationService = new Service.AccessoryInformation();


### PR DESCRIPTION
Fix #291
When joining two arrays, concat() does not modify the original array, it returns a new array concatenated array.