### PR TITLE
Fix for weather-formulas 1.0.9

### DIFF
--- a/apis/weatherflow.js
+++ b/apis/weatherflow.js
@@ -433,7 +433,7 @@ class TempestAPI
 				that.currentReport.DewPoint = wformula.temperature.kelvinToCelcius(wformula.temperature.dewPointMagnusFormula(
 					wformula.temperature.celciusToKelvin(that.currentReport.Temperature), 
 					that.currentReport.Humidity));
-				that.currentReport.TemperatureApparent = wformula.temperature.kelvinToCelcius(wformula.temperature.australianAapparentTemperature(
+				that.currentReport.TemperatureApparent = wformula.temperature.kelvinToCelcius(wformula.temperature.australianApparentTemperature(
 					wformula.temperature.celciusToKelvin(that.currentReport.Temperature),
 					that.currentReport.Humidity,
 					that.currentReport.WindSpeed));
@@ -529,7 +529,7 @@ class TempestAPI
 					wformula.temperature.celciusToKelvin(that.currentReport.Temperature), 
 					that.currentReport.Humidity));
 
-                that.currentReport.TemperatureApparent = wformula.temperature.kelvinToCelcius(wformula.temperature.australianAapparentTemperature(
+                that.currentReport.TemperatureApparent = wformula.temperature.kelvinToCelcius(wformula.temperature.australianApparentTemperature(
 					wformula.temperature.celciusToKelvin(that.currentReport.Temperature),
 					that.currentReport.Humidity,
 					message.obs[0][2]));

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "geo-tz": "^6.0.0",
     "moment-timezone": "^0.5.28",
     "axios": "^1.7.9",
-    "weather-formulas": "^1",
+    "weather-formulas": "^1.0.9",
     "node-persist": "^2.1.0",
     "debug": "^4.4.0"
   },


### PR DESCRIPTION
This is a fix for #313.

Also changed `package.json` to require 1.0.9 so the API spelling will match.