### PR TITLE
fix: prevent 'out of compliance' rejection in history fallback (#317)

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,9 +273,9 @@ WeatherPlusPlatform.prototype = {
 								accessory.historyService.addEntry({
 									time: new Date().getTime() / 1000,
 									temp: accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentTemperature).value,
-									pressure: accessory.AirPressureService ? accessory.AirPressureService.value : accessory.CurrentConditionsService.getCharacteristic(CustomCharacteristic.AirPressure).value,
+									pressure: accessory.AirPressureService ? accessory.AirPressureService.value : 0,
 									humidity: accessory.HumidityService ? accessory.HumidityService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value : accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value,
-									lux: accessory.LightLevelService ? accessory.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value
+									lux: accessory.LightLevelService ? accessory.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : 0
 								});
 							} catch (error2)
 							{


### PR DESCRIPTION
## Summary

Fixes the silent \`Accessory out of compliance\` rejection that has made the bridge unpairable since Apple tightened HAP strict-mode (~mid-May 2026). Tracked in #317, #311, #206.

## Root cause

In the fakegato \`historyService.addEntry({...})\` call in \`index.js\`, the \`pressure\` and \`lux\` fields fall back to \`accessory.CurrentConditionsService.getCharacteristic(...)\` when \`AirPressureService\` / \`LightLevelService\` does not exist. This is the common case when \`compatibility: \"home\"\` is used and the selected API (e.g. OpenWeatherMap) doesn't report \`LightLevel\` at all, or when the configuration suppresses \`AirPressureService\`.

\`Service.getCharacteristic()\` in hap-nodejs silently invokes \`addCharacteristic()\` if the characteristic is missing, which:

- mounts a non-conformant characteristic (\`AirPressure\` / \`CurrentAmbientLightLevel\`) onto a \`TemperatureSensor\` service, and
- emits the well-known \"Characteristic not in required or optional characteristic section for service TemperatureSensor. Adding anyway.\" warning.

Apple's HAP strict mode rejects the entire bridge silently as a result. The hap-nodejs warning is only logged but the actual pairing reject in the Home app is opaque (\"Accessory out of compliance\"). Users have been resetting bridges in a loop without finding the cause.

## Fix

Use \`: 0\` as the fallback when the dedicated service is missing. The value is irrelevant in that case (history just records a 0 placeholder for a metric that has no service) and the side-effect of mounting a stray characteristic on the temperature service is gone.

\`humidity\` is unchanged: \`CurrentRelativeHumidity\` is an optional characteristic on \`TemperatureSensor\` already, so its fallback path doesn't trigger the warning or the reject.

## Verification

- Homebridge 2.0.2, hap-nodejs 2.1.6, plugin 3.4.1, iOS strict-mode (May 2026)
- OpenWeatherMap API, \`compatibility: \"home\"\`
- Before patch: \"Accessory out of compliance\" on every pairing attempt; warning in log on every fakegato tick
- After patch: bridge pairs cleanly, history records normally in the Eve app (temperature and pressure graphs populate from the separate \`AirPressureService.value\`)

## Notes

The \`hidden\` config field has an unrelated but adjacent quirk: the schema enum uses display names with spaces (\`\"Air Pressure\"\`) but the runtime comparison is against CamelCase identifiers from \`reportCharacteristics\` (\`\"AirPressure\"\`), so spaces-form entries silently no-op. Not addressed in this PR — could be a follow-up either by normalising the comparison or switching the schema enum to CamelCase.