### PR TITLE
fix: accept both 'Air Pressure' and 'AirPressure' in hidden config

### DIFF
--- a/accessories/currentConditions.js
+++ b/accessories/currentConditions.js
@@ -67,7 +67,7 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 	// Add all current condition characteristics that are supported by the selected api
 	this.platform.stations[stationIndex].reportCharacteristics.forEach((name) =>
 	{
-		if (this.config.hidden.indexOf(name) === -1)
+		if (!compatibility.isHidden(this.config.hidden, name))
 		{
 			// Temperature is an official homekit characteristic
 			if (name === "Temperature")

--- a/accessories/forecast.js
+++ b/accessories/forecast.js
@@ -66,7 +66,7 @@ function ForecastWeatherAccessory(platform, stationIndex, day)
 	// Get all forecast characteristics that are supported by the selected api
 	this.platform.stations[stationIndex].forecastCharacteristics.forEach((name) =>
 	{
-		if (this.config.hidden.indexOf(name) === -1)
+		if (!compatibility.isHidden(this.config.hidden, name))
 		{
 			// Temperature is an official homekit characteristic
 			if (name === "TemperatureMax")

--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ WeatherPlusPlatform.prototype = {
 		// The passed in 'value' may be used later for comparison to trigger value(s) in the unconverted units
 		const convertedValue = name in CustomCharacteristic && CustomCharacteristic[name]._unitvalue ? CustomCharacteristic[name]._unitvalue(value) : value;
 
-		if (config.hidden.indexOf(name) === -1 || name === "Temperature" || name === "TemperatureMax")
+		if (!compatibility.isHidden(config.hidden, name) || name === "Temperature" || name === "TemperatureMax")
 		{
 			this.log.debug("Setting %s to %s", name, convertedValue);
 			// Temperature is an official homekit characteristic

--- a/util/compatibility.js
+++ b/util/compatibility.js
@@ -118,8 +118,36 @@ const getServices = function (that)
 	return services;
 };
 
+// Checks whether `name` (a CamelCase identifier from reportCharacteristics,
+// e.g. "AirPressure") is present in the user's `hidden` config array.
+//
+// Accepts either form for backwards compatibility:
+//   - CamelCase exactly as used internally:  "AirPressure"
+//   - The display form used in the schema:   "Air Pressure"
+//
+// The schema (config.schema.json) lists the display form with spaces, so
+// users wiring up "hidden" through the Homebridge UI / config-ui-x end up
+// with the space form, which previously silently no-op'd because the
+// runtime comparison was a literal Array.indexOf against the CamelCase name.
+const isHidden = function (hidden, name)
+{
+	if (!Array.isArray(hidden))
+	{
+		return false;
+	}
+	return hidden.some((entry) =>
+	{
+		if (typeof entry !== "string")
+		{
+			return false;
+		}
+		return entry === name || entry.replace(/ /g, "") === name;
+	});
+};
+
 module.exports = {
 	types,
 	createService,
-	getServices
+	getServices,
+	isHidden
 };


### PR DESCRIPTION
## Summary

The `config.schema.json` enum for `stations[].hidden` lists characteristic names with the display-form (spaces): `\"Air Pressure\"`, `\"Dew Point\"`, `\"Wind Speed\"`, etc. So users who configure `hidden` through the Homebridge UI / config-ui-x end up with the space form in their config.

But the runtime comparison in three places is a literal `Array.indexOf` against the CamelCase identifiers from each API's `reportCharacteristics` (\"AirPressure\", \"DewPoint\", \"WindSpeed\"). The space form silently no-ops — users hide e.g. \"Dew Point\" via the UI and wonder why the accessory keeps showing up in HomeKit.

This came up while debugging the strict-mode pairing reject from #317 — the workaround `hidden` arrays in the comments don't work as documented.

## Change

Add `util/compatibility.isHidden(hidden, name)` that accepts either form:
- CamelCase exactly as used internally (\"AirPressure\")
- The schema display form (\"Air Pressure\") — matched by stripping spaces

Refactor the three `hidden.indexOf(name) === -1` sites to use the helper:
- `index.js:324` (saveCharacteristic gate)
- `accessories/currentConditions.js:70` (reportCharacteristics loop)
- `accessories/forecast.js:69` (forecastCharacteristics loop)

## Compatibility

Existing configs that already use the CamelCase form continue to work unchanged — the helper short-circuits on direct string equality before doing the space-strip comparison.

## Verification

```
$ node -e \"const c = require('./util/compatibility');
console.log(c.isHidden(['Air Pressure'], 'AirPressure'));   // true
console.log(c.isHidden(['AirPressure'], 'AirPressure'));    // true
console.log(c.isHidden(['Air Pressure'], 'Humidity'));      // false
console.log(c.isHidden(undefined, 'AirPressure'));          // false
\"
true
true
false
false
```

Refs #317 (secondary finding mentioned in #319's comment).