### PR TITLE
fix: compatibility 'both' HAP strict-mode compliance — stop patching Custom Chars on main TempSensor

### DIFF
--- a/accessories/currentConditions.js
+++ b/accessories/currentConditions.js
@@ -80,17 +80,21 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			{
 				compatibility.createService(this, name, Service, Characteristic, CustomCharacteristic);
 			}
-			// Use separate services and the temperature service for these characteristics if compatiblity is "both"
+			// Use separate services for these characteristics if compatiblity is "both".
+			// CurrentRelativeHumidity is also added to the main TemperatureSensor
+			// because it is an official optional characteristic of that service.
+			// Other Custom Characteristics used to be added to the main
+			// TemperatureSensor too, but Apple's strict HAP validation rejects
+			// non-conformant characteristics on standard services as "Accessory
+			// out of compliance", so we only expose them on the separate services
+			// from now on. Eve still finds the values via the Custom UUIDs on
+			// those services and the fakegato history service is unaffected.
 			else if (this.config.compatibility === "both" && compatibility.types.includes(name))
 			{
 				compatibility.createService(this, name, Service, Characteristic, CustomCharacteristic);
 				if (name === "Humidity")
 				{
 					this.CurrentConditionsService.addCharacteristic(Characteristic.CurrentRelativeHumidity);
-				}
-				else
-				{
-					this.CurrentConditionsService.addCharacteristic(CustomCharacteristic[name]);
 				}
 			}
 			// Use separate service for humidity if configured

--- a/accessories/forecast.js
+++ b/accessories/forecast.js
@@ -79,17 +79,17 @@ function ForecastWeatherAccessory(platform, stationIndex, day)
 			{
 				compatibility.createService(this, name, Service, Characteristic, CustomCharacteristic);
 			}
-			// Use separate services and the temperature service for these characteristics if compatiblity is "both"
+			// Use separate services for these characteristics if compatiblity is "both".
+			// See the matching block in accessories/currentConditions.js for the
+			// reasoning — Apple's strict HAP validation rejects Custom Characteristics
+			// on standard services, so non-Humidity entries are no longer added to the
+			// forecast TemperatureSensor.
 			else if (this.config.compatibility === "both" && compatibility.types.includes(name))
 			{
 				compatibility.createService(this, name, Service, Characteristic, CustomCharacteristic);
 				if (name === "Humidity")
 				{
 					this.ForecastService.addCharacteristic(Characteristic.CurrentRelativeHumidity);
-				}
-				else
-				{
-					this.ForecastService.addCharacteristic(CustomCharacteristic[name]);
 				}
 			}
 			// Add humidity characteristic to temperature service

--- a/index.js
+++ b/index.js
@@ -329,19 +329,16 @@ WeatherPlusPlatform.prototype = {
 			{
 				temperatureService.setCharacteristic(Characteristic.CurrentTemperature, convertedValue);
 			}
-			// Compatibility characteristics have a separate service
+			// Compatibility characteristics have a separate service.
+			// In "both" mode the optional CurrentRelativeHumidity is also mirrored
+			// onto the main TemperatureSensor (HAP-compliant), but other Custom
+			// Characteristics are no longer written there to avoid Apple's
+			// strict-mode "Accessory out of compliance" rejection.
 			else if (["home", "both"].includes(config.compatibility) && compatibility.types.includes(name))
 			{
-				if (config.compatibility === "both")
+				if (config.compatibility === "both" && name === "Humidity")
 				{
-					if (name === "Humidity")
-					{
-						temperatureService.setCharacteristic(Characteristic.CurrentRelativeHumidity, convertedValue);
-					}
-					else
-					{
-						temperatureService.setCharacteristic(CustomCharacteristic[name], convertedValue);
-					}
+					temperatureService.setCharacteristic(Characteristic.CurrentRelativeHumidity, convertedValue);
 				}
 
 				if (name === "AirPressure")


### PR DESCRIPTION
## Summary

In `compatibility: \"both\"` mode the plugin creates the separate services via `compatibility.createService()` **and** additionally mounts the matching Custom Characteristic onto the main `TemperatureSensor` of every current-conditions and forecast accessory. The intent was a consolidated Eve-style tile showing all values on the standard TempSensor.

Apple HAP strict mode — tightened around mid-May 2026 — rejects the entire bridge as **\"Accessory out of compliance\"** when non-conformant Custom Characteristics live on a standard service. This is the primary root cause for `both`-mode users in #317.

## Change

In the three call sites that paired the extra `addCharacteristic`/`setCharacteristic` with the separate service creation (`accessories/currentConditions.js`, `accessories/forecast.js`, `index.js`), drop the non-Humidity branch:

- `Humidity` is kept as a duplicate on the main `TemperatureSensor` because `CurrentRelativeHumidity` is an **official optional characteristic** of `TemperatureSensor` — HAP-compliant, no strict-mode reject.
- Other Custom Characteristics (`AirPressure`, `CloudCover`, `DewPoint`, `UVIndex`, `WindSpeed`, …) are no longer added to the main TempSensor.

## Behaviour change for `both`-mode users

- **Apple Home app:** unchanged — Custom UUIDs were never rendered by Apple, so nothing visible disappears.
- **Eve app:** Custom Characteristics are located by UUID across all services, so the values still appear on the dedicated services that `compatibility.createService()` produces (OccupancySensor for AirPressure, CloudCover, …; TemperatureSensor for DewPoint/Apparent/Min; HumiditySensor for Humidity, etc.). The only change is that the **consolidated tile** view (all values on one Temperature tile) is no longer offered.
- **fakegato history:** untouched.

If a single-tile Eve view is desirable, that should be achieved with the `eve2` compatibility mode (`EveWeatherService` is the native Eve service type) rather than by patching characteristics onto a TempSensor.

## Verification

- Plugin loads without syntax errors (`node --check` on all three files).
- For a bridge configured with `compatibility: \"both\"` and OpenWeatherMap, the previously-silent characteristic-warnings logged by hap-nodejs (\"Characteristic not in required or optional characteristic section for service TemperatureSensor. Adding anyway.\") are no longer emitted for the affected Custom UUIDs.

Refs #317 (primary cause for the `both`-mode strict-mode reject), #311.