### PR TITLE
fix: scope Custom Chars on main service to eve/eve2 modes (residual strict-HAP compliance)

### DIFF
--- a/accessories/currentConditions.js
+++ b/accessories/currentConditions.js
@@ -108,8 +108,16 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			{
 				//
 			}
-			// illuminance is a general apple home kit characteristic
-			else if (name === "LightLevel")
+			// illuminance is a general apple home kit characteristic, but
+			// it is not in the required/optional set of a TemperatureSensor,
+			// so attaching it triggers Apple's strict-HAP "out of compliance"
+			// rejection in "home" and "both" modes. Only mount it onto the
+			// main service in the Eve-targeting compatibility modes — Eve
+			// renders it from the EveWeatherService (eve2) or the patched
+			// TempSensor (eve). For "home" / "both" users LightLevel should
+			// be exposed through a dedicated Service.LightSensor instead
+			// (see compatibility.types).
+			else if (name === "LightLevel" && (this.config.compatibility === "eve" || this.config.compatibility === "eve2"))
 			{
 				this.CurrentConditionsService.addCharacteristic(Characteristic.CurrentAmbientLightLevel);
 				// Override the defaults for light level as default is too low for daylight
@@ -134,8 +142,23 @@ function CurrentConditionsWeatherAccessory(platform, stationIndex)
 			{
 				this.CurrentConditionsService.addCharacteristic(Characteristic.StatusFault);
 			}
-			// Add everything else as a custom characteristic to the temperature service
-			else
+			// Add everything else as a custom characteristic to the main service.
+			// Custom characteristics on a standard TemperatureSensor are not
+			// part of the HAP optional set, so Apple's strict validation
+			// rejects the whole bridge as "Accessory out of compliance"
+			// once any non-conformant characteristic is mounted there.
+			// Only do this in the Eve-targeting compatibility modes:
+			//   - "eve":  the main service is still a TemperatureSensor but
+			//             the user opted into Eve-style display knowing
+			//             Apple Home will silently ignore the values.
+			//   - "eve2": the main service is the EveWeatherService — Eve's
+			//             own container type — so custom characteristics are
+			//             expected there.
+			// For "home" and "both" the value is still recorded in fakegato
+			// history and is available on the separate service produced by
+			// compatibility.createService() when the entry is in
+			// compatibility.types.
+			else if (this.config.compatibility === "eve" || this.config.compatibility === "eve2")
 			{
 				this.CurrentConditionsService.addCharacteristic(CustomCharacteristic[name]);
 			}

--- a/accessories/forecast.js
+++ b/accessories/forecast.js
@@ -97,8 +97,11 @@ function ForecastWeatherAccessory(platform, stationIndex, day)
 			{
 				this.ForecastService.addCharacteristic(Characteristic.CurrentRelativeHumidity);
 			}
-			// Add everything else as a custom characteristic to the temperature service
-			else
+			// See accessories/currentConditions.js for the rationale —
+			// only mount Custom Characteristics on the main forecast service
+			// in the Eve-targeting compatibility modes; "home" and "both"
+			// would be rejected by Apple's strict HAP validation.
+			else if (this.config.compatibility === "eve" || this.config.compatibility === "eve2")
 			{
 				this.ForecastService.addCharacteristic(CustomCharacteristic[name]);
 			}

--- a/index.js
+++ b/index.js
@@ -478,8 +478,14 @@ WeatherPlusPlatform.prototype = {
 					temperatureService.setCharacteristic(Characteristic.StatusFault, Characteristic.StatusFault.NO_FAULT);
 				}
 			}
-			// Set everything else as a custom characteristic in the temperature service
-			else
+			// Set everything else as a custom characteristic on the main service.
+			// Matches the accessory-construction guard in
+			// accessories/currentConditions.js + forecast.js — only the
+			// Eve-targeting compatibility modes mount Custom Characteristics
+			// on the main service, so we mirror that here. Writing into a
+			// characteristic that was never added would silently auto-add it
+			// via getCharacteristic() and trigger the strict-HAP rejection.
+			else if (config.compatibility === "eve" || config.compatibility === "eve2")
 			{
 				temperatureService.setCharacteristic(CustomCharacteristic[name], convertedValue);
 			}


### PR DESCRIPTION
## Summary

Residual strict-HAP compliance fix for the cases not covered by #319 and the \`both\`-mode PR. The per-characteristic loop in both accessory constructors has a default branch that adds every otherwise-unhandled characteristic to the main service as a Custom Characteristic, and the matching value-write path in \`index.js\` mirrors that shape.

In \`home\` and \`both\` compatibility modes the main service is a \`Service.TemperatureSensor\`. Custom Characteristics are not part of HAP's required/optional set of TemperatureSensor, so once any non-conformant characteristic is mounted there Apple's strict-HAP validation silently rejects the entire bridge as **\"Accessory out of compliance\"**. This applies to chars that are not in \`compatibility.types\` — typically: \`Condition\`, \`ConditionCategory\`, \`ObservationTime\`, \`Rain1h\`, \`SunriseTime\`, \`SunsetTime\`, \`ForecastDay\`, \`RainChance\` — and to the special \`LightLevel\` branch that mounts \`Characteristic.CurrentAmbientLightLevel\` (not optional on TempSensor either).

## Change

Guard the three call sites with a compatibility check:

- \`accessories/currentConditions.js\`: default branch and the LightLevel branch are scoped to \`compatibility === \"eve\" || compatibility === \"eve2\"\`.
- \`accessories/forecast.js\`: default branch scoped the same way.
- \`index.js#saveCharacteristic\`: default value-write scoped the same way, otherwise a \`setCharacteristic()\` on a missing characteristic would silently auto-add it via \`getCharacteristic()\` and re-trigger the strict-HAP reject.

Eve-targeting modes are unchanged:
- \`eve\` keeps the historic TempSensor-with-Custom-Chars layout the Eve app understands. Apple Home would still render nothing for those Custom UUIDs.
- \`eve2\` uses Eve's own \`EveWeatherService\` as the main service where Custom Characteristics are at home.

## Behaviour change for \`home\` / \`both\` users

- Apple Home: no visible change (Apple already silently ignored those Custom UUIDs); the bridge becomes pairable again under strict mode.
- Eve app: residual Custom Chars (Condition text, Sunrise time, …) that previously appeared as un-rendered properties of the TempSensor tile are no longer attached to it. Values that have a dedicated service via \`compatibility.createService()\` continue to be visible on those.
- fakegato history: untouched.

## Verification

- Plugin loads (\`node --check\` on all three files).
- For a bridge in \`compatibility: \"home\"\` with OpenWeatherMap the residual hap-nodejs warnings around \`SunriseTime\` / \`SunsetTime\` / \`Condition\` / etc. on TempSensor stop being emitted.

Refs #311, #315 (Sunrise/Sunset visibility is a symptom of this same issue), #317.