### PR TITLE
feat: apiVersion option for OpenWeatherMap (silence 'trying API 2.5' probe)

### DIFF
--- a/apis/openweathermap.js
+++ b/apis/openweathermap.js
@@ -7,10 +7,20 @@ const converter = require('../util/converter'),
 
 class OpenWeatherMapAPI
 {
-	constructor(apiKey, language, locationId, locationGeo, locationCity, conditionDetail, log)
+	constructor(apiKey, language, locationId, locationGeo, locationCity, conditionDetail, log, apiVersion)
 	{
 		this.log = log;
-		this.api = "3.0";
+		// apiVersion may be "auto" (default — try 3.0, fall back to 2.5 on 401),
+		// "3.0" (use One Call API 3.0, requires the paid subscription, no fallback)
+		// or "2.5" (skip the 3.0 probe and use the legacy free endpoints).
+		// The auto-fallback historically logged "Could not retrieve weather report
+		// with API 3.0, trying API 2.5 now ..." on every plugin start, which is
+		// expected for free-tier OpenWeatherMap API keys but creates the
+		// impression of a recurring error. Setting apiVersion="2.5" silences
+		// that and avoids the wasted initial 3.0 HTTP request.
+		const requestedVersion = apiVersion === "3.0" || apiVersion === "2.5" ? apiVersion : "auto";
+		this.apiAuto = requestedVersion === "auto";
+		this.api = requestedVersion === "2.5" ? "2.5" : "3.0";
 		this.apiBaseURL = "https://api.openweathermap.org";
 
 		this.apiKey = apiKey;
@@ -67,6 +77,18 @@ class OpenWeatherMapAPI
 		];
 		this.forecastDays = 8;
 		this.conditionDetail = conditionDetail;
+
+		// If the caller forced API 2.5, drop the 3.0-only characteristics up
+		// front so that the rest of the plugin sees the same shape as it
+		// would after a runtime fallback from 3.0.
+		if (this.api === "2.5")
+		{
+			this.removeCharacteristic(this.reportCharacteristics, "UVIndex");
+			this.removeCharacteristic(this.reportCharacteristics, "DewPoint");
+			this.removeCharacteristic(this.forecastCharacteristics, "UVIndex");
+			this.removeCharacteristic(this.forecastCharacteristics, "DewPoint");
+			this.forecastDays = 5;
+		}
 	}
 
 	update(forecastDays, callback)
@@ -127,7 +149,7 @@ class OpenWeatherMapAPI
 				{
 					if (error !== undefined && error.toString().includes("401"))
 					{
-						if (this.api === "3.0")
+						if (this.api === "3.0" && this.apiAuto)
 						{
 							that.log.info("Could not retreive weather report with API 3.0, trying API 2.5 now ...")
 							this.api = "2.5";
@@ -137,6 +159,14 @@ class OpenWeatherMapAPI
 							this.removeCharacteristic(this.forecastCharacteristics, "DewPoint");
 							this.forecastDays = 5;
 							this.update(forecastDays, callback);
+						}
+						else if (this.api === "3.0")
+						{
+							// apiVersion was pinned to "3.0" by config — no fallback.
+							that.log.error("Could not retreive weather report with API 3.0. Verify the api key has access to OneCall API 3.0, or set apiVersion to \"auto\" or \"2.5\" in the plugin config.");
+							that.log.error("Error result: " + result);
+							that.log.error("Error message: " + error);
+							callback();
 						}
 						else
 						{

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,17 @@
             "type": "string",
             "required": true
           },
+          "apiVersion": {
+            "type": "string",
+            "title": "OpenWeatherMap API version",
+            "description": "Only used when service is openweathermap. \"auto\" (default) probes One Call API 3.0 once and falls back to API 2.5 on a 401 — silently the historic behaviour. \"2.5\" skips the probe (recommended for free-tier API keys without OneCall 3.0). \"3.0\" pins OneCall 3.0 without fallback.",
+            "default": "auto",
+            "enum": [
+              "auto",
+              "2.5",
+              "3.0"
+            ]
+          },
           "locationGeo": {
             "type": "array",
             "maxItems": 2,

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function WeatherPlusPlatform(_log, _config)
 				break;
 			case "openweathermap":
 				this.log.info("Adding station with weather service OpenWeatherMap named '" + config.nameNow + "'");
-				this.stations.push(new openweathermap(config.key, config.language, config.locationId, config.locationGeo, config.locationCity, config.conditionDetail, this.log));
+				this.stations.push(new openweathermap(config.key, config.language, config.locationId, config.locationGeo, config.locationCity, config.conditionDetail, this.log, config.apiVersion));
 				break;
 			case "weewx":
 				this.log.info("Adding station with weather service Weewx named '" + config.nameNow + "'");
@@ -172,6 +172,15 @@ WeatherPlusPlatform.prototype = {
 
 		// Condition detail level
 		station.conditionDetail = stationConfig.conditionCategory || "simple";
+
+		// OpenWeatherMap API version selection. "auto" (default) probes 3.0
+		// once at start and falls back to 2.5 on a 401, which is the
+		// historic behaviour. "2.5" skips the probe entirely (use this if
+		// your API key does not have OneCall 3.0 — silences the recurring
+		// "Could not retreive weather report with API 3.0" info line on
+		// every plugin start). "3.0" pins the modern endpoint without
+		// fallback.
+		station.apiVersion = ["auto", "2.5", "3.0"].includes(stationConfig.apiVersion) ? stationConfig.apiVersion : "auto";
 
 		// Separate humidity accessory
 		station.extraHumidity = stationConfig.extraHumidity || false;


### PR DESCRIPTION
## Summary

Add a per-station \`apiVersion\` option for the OpenWeatherMap service. Lets users on a free-tier API key (no OneCall 3.0 subscription) pin the legacy 2.5 endpoint and silence the noisy

> Could not retreive weather report with API 3.0, trying API 2.5 now ...

info line that the plugin emits on every plugin / child-bridge start.

## Change

\`config.schema.json\` gets a new optional \`apiVersion\` string field with three enum values:

| Value | Behaviour |
|---|---|
| \`\"auto\"\` (default) | Historic probe-and-fallback: try 3.0 once, fall back to 2.5 on a 401. |
| \`\"2.5\"\` | Pin the legacy free endpoints. Skip the 3.0 probe entirely. \`reportCharacteristics\` and \`forecastCharacteristics\` are trimmed up front (UVIndex, DewPoint) so the rest of the plugin sees the same shape it would after a runtime fallback. |
| \`\"3.0\"\` | Pin OneCall 3.0. No fallback — log an error if the api key cannot reach it. Useful for paid-tier setups that want loud failures instead of silently degraded data. |

Wired through \`parseStationConfig\` to the \`OpenWeatherMapAPI\` constructor. The 401-fallback branch in \`update()\` now gates on \`this.apiAuto\` so a pinned-3.0 setup surfaces the failure instead of silently switching to 2.5.

## Backwards compatibility

\`apiVersion\` defaults to \`\"auto\"\`, which is the existing behaviour. Configs without the field are unchanged.

## Verification

- \`node --check\` on touched files passes.
- Schema validates as JSON.
- For a free-tier OWM key, setting \`\"apiVersion\": \"2.5\"\` skips the failed 3.0 HTTP request and the corresponding info-level log line at every plugin start.