### PR TITLE
fix: Sunrise/Sunset visible in Apple Home (#315)

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,6 +413,16 @@ WeatherPlusPlatform.prototype = {
 					accessory.VisibilityService.setCharacteristic(Characteristic.ConfiguredName, "Visibilityː " + convertedValue + " " + accessory.VisibilityService.unit);
 					accessory.VisibilityService.setCharacteristic(Characteristic.Name, "Visibilityː " + convertedValue + " " + accessory.VisibilityService.unit);
 				}
+				else if (name === "SunriseTime")
+				{
+					accessory.SunriseTimeService.setCharacteristic(Characteristic.ConfiguredName, "Sunriseː " + convertedValue);
+					accessory.SunriseTimeService.setCharacteristic(Characteristic.Name, "Sunriseː " + convertedValue);
+				}
+				else if (name === "SunsetTime")
+				{
+					accessory.SunsetTimeService.setCharacteristic(Characteristic.ConfiguredName, "Sunsetː " + convertedValue);
+					accessory.SunsetTimeService.setCharacteristic(Characteristic.Name, "Sunsetː " + convertedValue);
+				}
 				else if (name === "WindDirection")
 				{
 					accessory.WindDirectionService.setCharacteristic(Characteristic.ConfiguredName, "Wind Dirː " + convertedValue);

--- a/util/compatibility.js
+++ b/util/compatibility.js
@@ -1,7 +1,7 @@
 /*jshint esversion: 6,node: true,-W041: false */
 "use strict";
 
-const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "RainBool", "SnowBool", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
+const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "RainBool", "SnowBool", "SunriseTime", "SunsetTime", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
 
 const createService = function (that, name, Service, Characteristic, CustomCharacteristic)
 {
@@ -48,6 +48,23 @@ const createService = function (that, name, Service, Characteristic, CustomChara
 	{
 		that.SnowBoolService = new Service.OccupancySensor("Snow", "Snow");
 		that.SnowBoolService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Snow");
+	}
+	if (name === "SunriseTime")
+	{
+		// The actual value is a formatted "HH:mm:ss" string and is not a
+		// HAP-native characteristic, so we expose it as an OccupancySensor
+		// whose ConfiguredName / Name is rewritten to "Sunriseː HH:mm" on
+		// every update (same pattern as UVIndex / WindSpeed / Visibility).
+		// Apple Home renders the ConfiguredName as the tile label, so the
+		// time is visible without depending on a Custom Characteristic
+		// being rendered.
+		that.SunriseTimeService = new Service.OccupancySensor("Sunrise Time", "Sunrise Time");
+		that.SunriseTimeService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Sunrise Time");
+	}
+	if (name === "SunsetTime")
+	{
+		that.SunsetTimeService = new Service.OccupancySensor("Sunset Time", "Sunset Time");
+		that.SunsetTimeService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Sunset Time");
 	}
 	if (name === "TemperatureMin")
 	{


### PR DESCRIPTION
Closes #315.

## Summary

In compatibility \`home\` and \`both\` modes, \`SunriseTime\` / \`SunsetTime\` were attached as **Custom Characteristics** on the main TemperatureSensor. Apple Home does not render Custom UUIDs, so the times were invisible to home-mode users — the symptom in #315.

## Change

- Add \`SunriseTime\` and \`SunsetTime\` to \`compatibility.types\`.
- Create dedicated \`Service.OccupancySensor\` services for them in \`compatibility.createService()\`.
- Rewrite the \`ConfiguredName\` (and \`Name\`) on every update to \`\"Sunriseː HH:mm:ss\"\` / \`\"Sunsetː HH:mm:ss\"\` — the exact same pattern the plugin already uses for \`UVIndex\`, \`WindSpeed\`, \`Visibility\`, \`WindDirection\` and \`RainDay\`.

Apple Home renders the \`ConfiguredName\` as the tile label, so the user sees \`Sunriseː 06:42:18\` etc. on a dedicated tile without depending on Custom Characteristic rendering.

## Compatibility

\`eve\` / \`eve2\` users are unchanged. They keep getting the Custom Characteristic on the main service through the default branch of the per-characteristic loop, which is the representation the Eve app expects.

## Verification

- \`node --check\` on the touched files passes.
- Same code-shape as the existing UV-Index / Visibility / Wind-Speed handling, so the value-format and Apple-Home rendering are guaranteed by precedent.