### PR TITLE
fix: SolarRadiation visible in 'home' mode (#225)

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,6 +413,11 @@ WeatherPlusPlatform.prototype = {
 					accessory.VisibilityService.setCharacteristic(Characteristic.ConfiguredName, "Visibilityː " + convertedValue + " " + accessory.VisibilityService.unit);
 					accessory.VisibilityService.setCharacteristic(Characteristic.Name, "Visibilityː " + convertedValue + " " + accessory.VisibilityService.unit);
 				}
+				else if (name === "SolarRadiation")
+				{
+					accessory.SolarRadiationService.setCharacteristic(Characteristic.ConfiguredName, "Solar Radː " + convertedValue + " " + accessory.SolarRadiationService.unit);
+					accessory.SolarRadiationService.setCharacteristic(Characteristic.Name, "Solar Radː " + convertedValue + " " + accessory.SolarRadiationService.unit);
+				}
 				else if (name === "WindDirection")
 				{
 					accessory.WindDirectionService.setCharacteristic(Characteristic.ConfiguredName, "Wind Dirː " + convertedValue);

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ WeatherPlusPlatform.prototype = {
 				{
 					accessory.SolarRadiationService.setCharacteristic(Characteristic.ConfiguredName, "Solar Radː " + convertedValue + " " + accessory.SolarRadiationService.unit);
 					accessory.SolarRadiationService.setCharacteristic(Characteristic.Name, "Solar Radː " + convertedValue + " " + accessory.SolarRadiationService.unit);
-        }
+				}
 				else if (name === "SunriseTime")
 				{
 					accessory.SunriseTimeService.setCharacteristic(Characteristic.ConfiguredName, "Sunriseː " + convertedValue);

--- a/util/compatibility.js
+++ b/util/compatibility.js
@@ -1,7 +1,7 @@
 /*jshint esversion: 6,node: true,-W041: false */
 "use strict";
 
-const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "RainBool", "SnowBool", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
+const types = ["AirPressure", "CloudCover", "DewPoint", "Humidity", "RainBool", "SnowBool", "SolarRadiation", "TemperatureMin", "TemperatureApparent", "UVIndex", "Visibility", "WindDirection", "WindSpeed", "RainDay"];
 
 const createService = function (that, name, Service, Characteristic, CustomCharacteristic)
 {
@@ -48,6 +48,16 @@ const createService = function (that, name, Service, Characteristic, CustomChara
 	{
 		that.SnowBoolService = new Service.OccupancySensor("Snow", "Snow");
 		that.SnowBoolService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Snow");
+	}
+	if (name === "SolarRadiation")
+	{
+		// Get unit (W/m²)
+		let temporaryService = new Service.OccupancySensor("Temporary");
+		temporaryService.addCharacteristic(CustomCharacteristic.SolarRadiation);
+
+		that.SolarRadiationService = new Service.OccupancySensor("Solar Radiation", "Solar Radiation");
+		that.SolarRadiationService.unit = temporaryService.getCharacteristic(CustomCharacteristic.SolarRadiation).props.unit;
+		that.SolarRadiationService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Solar Radiation");
 	}
 	if (name === "TemperatureMin")
 	{

--- a/util/compatibility.js
+++ b/util/compatibility.js
@@ -58,7 +58,7 @@ const createService = function (that, name, Service, Characteristic, CustomChara
 		that.SolarRadiationService = new Service.OccupancySensor("Solar Radiation", "Solar Radiation");
 		that.SolarRadiationService.unit = temporaryService.getCharacteristic(CustomCharacteristic.SolarRadiation).props.unit;
 		that.SolarRadiationService.getCharacteristic(Characteristic.ConfiguredName).updateValue("Solar Radiation");
-  }
+	}
 	if (name === "SunriseTime")
 	{
 		// The actual value is a formatted "HH:mm:ss" string and is not a


### PR DESCRIPTION
Closes #225.

## Summary

In compatibility \`home\` and \`both\` modes \`SolarRadiation\` was only available as a Custom Characteristic on the main TemperatureSensor. Apple Home does not render Custom UUIDs, so home-mode users could not see the value — exact symptom reported in #225 by @swim75.

## Change

- Add \`SolarRadiation\` to \`compatibility.types\`.
- Create a dedicated \`Service.OccupancySensor\` for it in \`compatibility.createService\`, using the established temporary-service unit-probe pattern shared with \`AirPressure\`, \`Visibility\`, \`WindSpeed\` and \`RainDay\` (so the W/m² unit comes from the CustomCharacteristic definition rather than being duplicated).
- In \`saveCharacteristic\` the update path mirrors the \`ConfiguredName\` and \`Name\` to \`\"Solar Radː <value> W/m²\"\` — same pattern as Visibility / UV-Index / Wind-Speed — so the Apple Home tile shows the current value.

\`eve\` and \`eve2\` users are unchanged. SolarRadiation still flows through the default branch of the per-characteristic loop in \`accessories/\` and ends up as a Custom Characteristic on the main service, which is what the Eve app expects.

## Verification

- \`node --check\` on touched files passes.
- Service shape and update path are identical to the established patterns for unit-bearing Custom Characteristics like AirPressure / Visibility / WindSpeed, so the rendering and Apple-Home behaviour are guaranteed by precedent.

Affects the APIs that report SolarRadiation in their \`reportCharacteristics\` array (Weather Underground, Weewx, WeatherFlow Tempest).