### PR TITLE
General fixes. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,4 +316,5 @@
 
 ## 3.5.1
 * Fixed accessory out of compliance error with HomeBridge 2.0
-* Fixed Eve (with grouping) compatibility option
+* Fixed Eve (with grouping) compatibility option from crashing on startup
+* Fixed missing Pressure & Light history in eve/eve2 data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,3 +313,7 @@
 * Fixed hiding Air Pressure, Dew Point and Wind Speed by config has no effect
 * Added solar radiation to apple home compatibility mode
 * Added sunrise and sunset to apple home compatibility mode
+
+## 3.5.1
+* Fixed accessory out of compliance error with HomeBridge 2.0
+* Fixed Eve (with grouping) compatibility option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,8 +313,3 @@
 * Fixed hiding Air Pressure, Dew Point and Wind Speed by config has no effect
 * Added solar radiation to apple home compatibility mode
 * Added sunrise and sunset to apple home compatibility mode
-
-## 3.5.1
-* Fixed accessory out of compliance error with HomeBridge 2.0
-* Fixed Eve (with grouping) compatibility option from crashing on startup
-* Fixed missing Pressure & Light history in eve/eve2 data

--- a/index.js
+++ b/index.js
@@ -270,10 +270,19 @@ WeatherPlusPlatform.prototype = {
 								});
 
 								this.log.debug("Saving history entry");
+								// Read pressure from the raw report value rather than the HomeKit
+								// characteristic: AirPressure is UINT16/minStep 1 so it loses the
+								// decimals the Eve graph relies on. Store raw hPa (no unit conversion)
+								// so the value is correct regardless of the user's unit setting.
+								// Never store 0 — it wrecks graph scaling since real pressure only
+								// varies a little — so reuse the last known value until a real
+								// reading arrives.
+								let pressure = (data.AirPressure !== undefined) ? data.AirPressure : 0;
+								if (pressure) accessory.lastHistoryPressure = pressure;
 								accessory.historyService.addEntry({
 									time: new Date().getTime() / 1000,
 									temp: accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentTemperature).value,
-									pressure: accessory.AirPressureService ? accessory.AirPressureService.value : (accessory.CurrentConditionsService.testCharacteristic(CustomCharacteristic.AirPressure) ? accessory.CurrentConditionsService.getCharacteristic(CustomCharacteristic.AirPressure).value : 0),
+									pressure: accessory.lastHistoryPressure || 0,
 									humidity: accessory.HumidityService ? accessory.HumidityService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value : accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value,
 									lux: accessory.LightLevelService ? accessory.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : (accessory.CurrentConditionsService.testCharacteristic(Characteristic.CurrentAmbientLightLevel) ? accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : 0)
 								});

--- a/index.js
+++ b/index.js
@@ -273,9 +273,9 @@ WeatherPlusPlatform.prototype = {
 								accessory.historyService.addEntry({
 									time: new Date().getTime() / 1000,
 									temp: accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentTemperature).value,
-									pressure: accessory.AirPressureService ? accessory.AirPressureService.value : 0,
+									pressure: accessory.AirPressureService ? accessory.AirPressureService.value : (accessory.CurrentConditionsService.testCharacteristic(CustomCharacteristic.AirPressure) ? accessory.CurrentConditionsService.getCharacteristic(CustomCharacteristic.AirPressure).value : 0),
 									humidity: accessory.HumidityService ? accessory.HumidityService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value : accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentRelativeHumidity).value,
-									lux: accessory.LightLevelService ? accessory.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : 0
+									lux: accessory.LightLevelService ? accessory.LightLevelService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : (accessory.CurrentConditionsService.testCharacteristic(Characteristic.CurrentAmbientLightLevel) ? accessory.CurrentConditionsService.getCharacteristic(Characteristic.CurrentAmbientLightLevel).value : 0)
 								});
 							} catch (error2)
 							{

--- a/index.js
+++ b/index.js
@@ -170,8 +170,8 @@ WeatherPlusPlatform.prototype = {
 		station.compatibility = "currentObservations" in stationConfig && stationConfig.currentObservations === "eve" ? "eve2" : station.compatibility; // old eve is now eve2
 		station.compatibility = ["eve", "eve2", "home", "both"].includes(station.compatibility) ? station.compatibility : "eve";
 
-		// Condition detail level
-		station.conditionDetail = stationConfig.conditionCategory || "simple";
+		// Condition detail level — stored as boolean so downstream detail ? x : y checks work correctly
+		station.conditionDetail = (stationConfig.conditionCategory === 'detailed');
 
 		// Separate humidity accessory
 		station.extraHumidity = stationConfig.extraHumidity || false;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-weather-plus",
   "displayName": "Weather Plus",
-  "version": "3.5.1",
+  "version": "3.5.0-beta.1",
   "description": "A comprehensive weather plugin for homekit with current observations, forecasts and history.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "url": "https://github.com/naofireblade/homebridge-weather-plus.git"
   },
   "dependencies": {
-    "fakegato-history": "^0.6.4",
+    "fakegato-history": "^0.6.7",
     "geo-tz": "^6.0.0",
     "moment-timezone": "^0.5.28",
     "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-weather-plus",
   "displayName": "Weather Plus",
-  "version": "3.5.0-beta.1",
+  "version": "3.5.1",
   "description": "A comprehensive weather plugin for homekit with current observations, forecasts and history.",
   "license": "MIT",
   "keywords": [

--- a/util/services.js
+++ b/util/services.js
@@ -1,6 +1,5 @@
 /* jshint asi: true, esversion: 6, laxbreak: true, laxcomma: true, node: true, undef: true, unused: true */
 
-const inherits = require('util').inherits;
 const CustomUUID = {
 	// Eve UUID
 	EveWeather: 'E863F001-079E-48FF-8F27-9C2605A29F52'
@@ -10,12 +9,14 @@ let CustomService = {};
 
 module.exports = function (Service, Characteristic)
 {
-	CustomService.EveWeatherService = function (displayName, subtype)
-	{
-		Service.call(this, displayName, CustomUUID.EveWeather, subtype);
-		this.addCharacteristic(Characteristic.CurrentTemperature);
-	};
-	inherits(CustomService.EveWeatherService, Service);
+	class EveWeatherService extends Service {
+		constructor(displayName, subtype)
+		{
+			super(displayName, CustomUUID.EveWeather, subtype);
+			this.addCharacteristic(Characteristic.CurrentTemperature);
+		}
+	}
+	CustomService.EveWeatherService = EveWeatherService;
 
 	return CustomService;
 };


### PR DESCRIPTION
* Fix the case if you pick compatibility Eve (with Grouping), ie `eve2`, it crashes:
[fix: convert EveWeatherService to ES6 class for HAP-NodeJS compatibility (Eve2 grouping)](https://github.com/naofireblade/homebridge-weather-plus/commit/d499d57fcbaa0582acfe9907bd2b629d7ab83967)
* Ensure that the newest Fakogato is being used, needed to avoid Out Of Compliance error when pairing:
[New FakeGato for HB 2.0](https://github.com/naofireblade/homebridge-weather-plus/commit/ccefda798d50bc6b0c1907db16857a56a73a0f2e)
* AirPressure and Light history data can be missing when using eve/eve2 compatibility. It was only recording if you had the extra sensor enabled:
[fix: record AirPressure/LightLevel history in eve/eve2 compatibility …](https://github.com/naofireblade/homebridge-weather-plus/commit/822aa7dcdc242da6806241062dfb988ecc8f5394)
* AirPressure was being converted to user's specified units, which is not what Eve expects:
[fix: store full-precision raw hPa pressure in Eve history](https://github.com/naofireblade/homebridge-weather-plus/commit/4f86fc9888489c6227da24f3cf9a5759b1f5a723)
* Condition detail was always `detailed` regardless of setting because the variable stored a string, but was used as a boolean in the code. 
[fix: conditionDetail was always truthy, making simple mode behave as …](https://github.com/naofireblade/homebridge-weather-plus/commit/bd131a32f7ec964baf041b4b1f49f220efcc90ba)